### PR TITLE
Deal with soh

### DIFF
--- a/loadStationXML
+++ b/loadStationXML
@@ -47,6 +47,8 @@ if __name__ == "__main__":
     parser.add_argument("-v","--verbose",help=help_text,action="store_true")
     help_text = "Add currently active channels only"
     parser.add_argument("-a","--active",help=help_text,action="store_true")
+    help_text = "Load all SOH channels, default is '[BEHS][HLN]*' (ignored when -c is provided)"
+    parser.add_argument("-i", "--inclusive", help=help_text, action="store_true")
     help_text = "Specify a station code, wildcards are allowed"
     parser.add_argument("-s","--station",help=help_text)
     help_text = "Specify a channel code, wildcards are allowed"
@@ -56,6 +58,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     active_flag = False
+    inclusive = False
 
     # possible keyword arguments to use in select
     kwargs = {}
@@ -67,14 +70,16 @@ if __name__ == "__main__":
         kwargs["location"] = args.location
     if args.active:
         active_flag=True
-    #    kwargs["starttime"] = UTCDateTime(datetime.datetime.utcnow())
+    if not args.inclusive and not args.channel:
+        # unless otherwise specified, restrict to seismic channels
+        kwargs["channel"] = '[BEHS][HNL]*'
 
     logfile = "loadStationXML_{}.log".format(datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'))
-    logging.basicConfig(filename=logfile, level=logging.INFO)
+    logging.basicConfig(filename=logfile, level=logging.WARNING)
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+    logging.getLogger('sqlalchemy.engine').setLevel(logging.WARNING)
     
     # This command will create the database tables if they do not exist yet.
     Base.metadata.create_all(engine)

--- a/loadStationXML
+++ b/loadStationXML
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     parser.add_argument("-v","--verbose",help=help_text,action="store_true")
     help_text = "Add currently active channels only"
     parser.add_argument("-a","--active",help=help_text,action="store_true")
-    help_text = "Load all SOH channels, default is '[BEHS][HLN]*' (ignored when -c is provided)"
+    help_text = "Load all SOH channels, default is '[BEHS][HLN][123ENZ]' (ignored when -c is provided)"
     parser.add_argument("-i", "--inclusive", help=help_text, action="store_true")
     help_text = "Specify a station code, wildcards are allowed"
     parser.add_argument("-s","--station",help=help_text)
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         active_flag=True
     if not args.inclusive and not args.channel:
         # unless otherwise specified, restrict to seismic channels
-        kwargs["channel"] = '[BEHS][HNL]*'
+        kwargs["channel"] = '[BEHS][HNL][123ENZ]'
 
     logfile = "loadStationXML_{}.log".format(datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S'))
     logging.basicConfig(filename=logfile, level=logging.WARNING)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name="aqms-ir", 
-    version="0.3.5",
+    version="0.4.0",
     description="translation between obspy Inventory object and AQMS schema",
     url="http://github.com/pnsn/aqms-ir",
     author="Renate Hartog",
@@ -9,7 +9,7 @@ setup(name="aqms-ir",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3,2.7',
         'Intended Audience :: Science/Research',
     ],
     packages=["aqms_ir"],


### PR DESCRIPTION
Changed logic so that only seismic channels will be loaded by default (when channels are not constrained by -c flag and --inclusive flag not set), defined as follows:

* channel_code[0] has to be one of B, E, H, S (indicates sample rate)
* channel_code[1] has to be one of H,N,L (indicates type of seismic sensor)
* channel_code[2] has to be one of 1,2,3,E,N,Z (indicates component)